### PR TITLE
Android - Get context after realoding device

### DIFF
--- a/android/src/main/java/com/rnopentok/RNOpenTokSessionManager.java
+++ b/android/src/main/java/com/rnopentok/RNOpenTokSessionManager.java
@@ -43,8 +43,18 @@ public class RNOpenTokSessionManager implements Session.SessionListener, Session
                 e.printStackTrace();
             }
             instance = new RNOpenTokSessionManager(context, apiKey);
+        } else if ( context != null && instance.getContext() != context) {
+            instance.setContext(context);
         }
         return instance;
+    }
+
+    public ReactApplicationContext getContext() {
+        return this.mContext;
+    }
+
+    public void setContext(ReactApplicationContext context) {
+        this.mContext = context;
     }
 
     static RNOpenTokSessionManager getSessionManager() {


### PR DESCRIPTION
fixes #68 

Now we set proper context on reload, so we can see events. 

🐛 🐛 🐛  Found bug that event listener isn't removed with `OpenTok.removeListener()`