### PR TITLE
Return 0 in non-void stopCapture

### DIFF
--- a/ios/RNOpenTokScreenSharingCapturer.m
+++ b/ios/RNOpenTokScreenSharingCapturer.m
@@ -130,6 +130,8 @@
             dispatch_source_cancel(_timer);
         }
     });
+    
+    return 0;
 }
 
 - (BOOL)isCaptureStarted


### PR DESCRIPTION
My build was failing with a `control reaches end of non-void block` error. Always return 0 since function expects to return int. Could also change function signature to be void - not an Obj C guy, so let me know if there is a better way to fix this.