### PR TITLE
Updated README file with new events

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,11 @@ Constants for events thrown in app. Available values:
 - *ON_SESSION_DID_FAIL_WITH_ERROR*
 - *ON_SESSION_STREAM_CREATED*
 - *ON_SESSION_STREAM_DESTROYED*
+- *ERROR_NO_SCREEN_CAPTURE_VIEW*
+- *ON_ARCHIVE_STARTED_WITH_ID*
+- *ON_ARCHIVE_STOPPED_WITH_ID*
+- *ON_SESSION_DID_BEGIN_RECONNECTING*
+- *ON_SESSION_DID_RECONNECT*
 
 #### on(name: string, callback: Function)
 Event listener, for events listed above.


### PR DESCRIPTION
Updated react-native-opentok's documentation with the new events:

 _ON_ARCHIVE_STARTED_WITH_ID_
_ON_ARCHIVE_STOPPED_WITH_ID_
 _ON_SESSION_DID_BEGIN_RECONNECTING_
 _ON_SESSION_DID_RECONNECT_