### PR TITLE
Bump version of android opentok sdk to 2.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 -  `react-native` >=0.49.3
 
 Supported OpenTok SDK version:
-- `OpenTok SDK` 2.12.+
+- `OpenTok SDK` 2.13.+
 
 ## Table of contents
 - [Installation](#installation)

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,5 +32,5 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.opentok.android:opentok-android-sdk:2.12.+'
+    compile 'com.opentok.android:opentok-android-sdk:2.13.+'
 }


### PR DESCRIPTION
This is necessary for safari browser support: https://tokbox.com/developer/sdks/js/safari/