### PR TITLE
Fixing warning message

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -12,8 +12,8 @@ buildscript {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
-    buildToolsVersion "23.0.1"
+    compileSdkVersion 28
+    buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 16

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -31,6 +31,6 @@ repositories {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:+'
-    compile 'com.opentok.android:opentok-android-sdk:2.15.+'
+    implementation 'com.facebook.react:react-native:+'
+    implementation 'com.opentok.android:opentok-android-sdk:2.15.+'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -32,5 +32,5 @@ repositories {
 
 dependencies {
     compile 'com.facebook.react:react-native:+'
-    compile 'com.opentok.android:opentok-android-sdk:2.13.+'
+    compile 'com.opentok.android:opentok-android-sdk:2.15.+'
 }

--- a/android/src/main/java/com/rnopentok/RNOpenTokScreenSharingCapturer.java
+++ b/android/src/main/java/com/rnopentok/RNOpenTokScreenSharingCapturer.java
@@ -50,7 +50,7 @@ public class RNOpenTokScreenSharingCapturer extends BaseVideoCapturer {
                     canvas = new Canvas(bmp);
                     frame = new int[width * height];
                 }
-                canvas.save(Canvas.MATRIX_SAVE_FLAG);
+                canvas.save();
                 canvas.translate(-mView.getScrollX(), -mView.getScrollY());
                 mView.draw(canvas);
                 bmp.getPixels(frame, 0, width, 0, 0, width, height);


### PR DESCRIPTION
Hello,

My PR have a bit of change on `compileSdkVersion` and `buildToolsVersion` from 23 to 28, using `implementation` instead of `compile` and remove `Canvas.MATRIX_SAVE_FLAG` 